### PR TITLE
Move PR check back to separate job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,10 +11,19 @@ jobs:
     steps:
       - checkout
       - run: npm ci
-      - run: npx auto pr-check --url ${CIRCLE_BUILD_URL}
       - run: npx auto shipit
+  pr_check:
+    <<: *defaults
+    steps:
+      - checkout
+      - run: npx auto pr-check --url ${CIRCLE_BUILD_URL}
 
 workflows:
   build_and_release:
     jobs:
       - release
+      - pr_check:
+          filters:
+            branches:
+              ignore:
+                - master


### PR DESCRIPTION
# Release Notes
```yml
pr_check:
    <<: *defaults
    steps:
      - checkout
      - run: npx auto pr-check --url ${CIRCLE_BUILD_URL}

- pr_check:
          filters:
            branches:
              ignore:
                - master
```
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.2.2-canary.5.43.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install auto-demo@1.2.2-canary.5.43.0
  # or 
  yarn add auto-demo@1.2.2-canary.5.43.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
